### PR TITLE
Add modulesDirectores to wabpack config

### DIFF
--- a/src/actions/pokemon.js
+++ b/src/actions/pokemon.js
@@ -1,10 +1,10 @@
 import fetch from 'isomorphic-fetch';
 import { polyfill } from 'es6-promise';
 
-import * as actionTypes from '../constants/actionTypes'
-import * as statusConstants from '../constants/status';
+import * as actionTypes from 'constants/actionTypes'
+import * as statusConstants from 'constants/status';
 import { setStatus } from './status';
-import getEntrypointFor from '../helpers/get-entrypoint-for';
+import getEntrypointFor from 'helpers/get-entrypoint-for';
 
 export function fetchPokemonSuccess(data) {
   return {

--- a/src/actions/pokemons.js
+++ b/src/actions/pokemons.js
@@ -1,8 +1,8 @@
 import fetch from 'isomorphic-fetch';
 import { polyfill } from 'es6-promise';
 
-import * as actionTypes from '../constants/actionTypes'
-import getEntrypointFor from '../helpers/get-entrypoint-for';
+import * as actionTypes from 'constants/actionTypes'
+import getEntrypointFor from 'helpers/get-entrypoint-for';
 import { setStatus } from './status';
 import {
   LOADING_STATUS,
@@ -10,7 +10,7 @@ import {
   NULL_STATUS,
   NETWORK_ERROR,
   NETWORK_ERROR_MESSAGE
-}  from '../constants/status';
+}  from 'constants/status';
 
 export function fetchPokedexSuccess(data) {
   return {

--- a/src/actions/status.js
+++ b/src/actions/status.js
@@ -1,4 +1,4 @@
-import * as actionTypes from '../constants/actionTypes'
+import * as actionTypes from 'constants/actionTypes'
 
 export function setStatus(data) {
   return {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { AppBar, AutoComplete, TextField } from 'material-ui';
 
 import Pokeball from './Pokeball';
-import navigate from '../helpers/navigate';
+import navigate from 'helpers/navigate';
 
 const Header = ({
   history,
@@ -11,7 +11,7 @@ const Header = ({
   onSearchSubmit,
 }) => (
   <header>
-    <AppBar 
+    <AppBar
       style={{
         paddingLeft: 60
       }}

--- a/src/components/PokedexList/index.js
+++ b/src/components/PokedexList/index.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 import styles from './PokedexList.css';
-import PokedexItem from '../PokedexItem';
+import PokedexItem from 'components/PokedexItem';
 
 const PokedexList = ({
   list,

--- a/src/components/Status/index.js
+++ b/src/components/Status/index.js
@@ -5,7 +5,7 @@ import { random, times } from 'lodash';
 import { LinearProgress } from 'material-ui';
 
 import styles from './Status.css';
-import { NULL_STATUS, NETWORK_ERROR } from '../../constants/status'
+import { NULL_STATUS, NETWORK_ERROR } from 'constants/status'
 
 // TODO: update to something more smart than this.
 const images = times(4).map((x) => require(`./images/0${x}.gif`));

--- a/src/components/Welcome/index.js
+++ b/src/components/Welcome/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import styles from './Welcome.css';
-import navigate from '../../helpers/navigate';
+import navigate from 'helpers/navigate';
 
 const Welcome = ({
   history,

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -4,12 +4,12 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Paper } from 'material-ui';
 
-import * as pokemonActions from '../../actions/pokemon';
-import Status from '../../components/Status';
-import Header from '../../components/Header';
-import Footer from '../../components/Footer';
-import Welcome from '../../components/Welcome';
-import { GITHUB_REPO_URL, TWITTER_PROFILE_URL, TWITTER_PROFILE } from '../../constants/appConfig';
+import * as pokemonActions from 'actions/pokemon';
+import Status from 'components/Status';
+import Header from 'components/Header';
+import Footer from 'components/Footer';
+import Welcome from 'components/Welcome';
+import { GITHUB_REPO_URL, TWITTER_PROFILE_URL, TWITTER_PROFILE } from 'constants/appConfig';
 import styles from './App.css';
 
 function mapStateToProps({ status, pokemons }) {

--- a/src/containers/Pokedex/index.js
+++ b/src/containers/Pokedex/index.js
@@ -4,12 +4,12 @@ import { chunk } from 'lodash';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-import * as pokemonsActions from '../../actions/pokemons';
+import * as pokemonsActions from 'actions/pokemons';
 import styles from './Pokedex.css';
-import PokedexList from '../../components/PokedexList';
-import PokedexItem from '../../components/PokedexItem';
-import Paginator from '../../components/Paginator';
-import Warning from '../../components/Warning';
+import PokedexList from 'components/PokedexList';
+import PokedexItem from 'components/PokedexItem';
+import Paginator from 'components/Paginator';
+import Warning from 'components/Warning';
 
 
 function mapStateToProps({ pokemons, filter }) {

--- a/src/containers/Pokemon/index.js
+++ b/src/containers/Pokemon/index.js
@@ -4,9 +4,9 @@ import { connect } from 'react-redux';
 import { List, ListItem, Divider } from 'material-ui';
 import { FaHandGrabO, FaShield, FaBarChart, FaSmileO, FaArrowsV, FaHeart } from 'react-icons';
 
-import * as pokemonActions from '../../actions/pokemon';
+import * as pokemonActions from 'actions/pokemon';
 import styles from './Pokemon.css';
-import Title from '../../components/title';
+import Title from 'components/Title';
 
 function mapStateToProps({ pokemon }) {
   return {

--- a/src/helpers/get-entrypoint-for.js
+++ b/src/helpers/get-entrypoint-for.js
@@ -3,7 +3,7 @@ import {
   POKEAPI_POKEDEX_URL,
   POKEAPI_POKEMON_URL,
   POKEAPI_IMAGE_URL,
-} from '../constants/services';
+} from 'constants/services';
 
 const alias = {
   root: '',

--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,11 @@ let history = createHashHistory({
   queryKey: false
 });
 
-import App from './containers/App';
-import Pokedex from './containers/Pokedex';
-import Pokemon from './containers/Pokemon';
-import DevTools from './containers/DevTools';
-import configureStore from './store/configureStore';
+import App from 'containers/App';
+import Pokedex from 'containers/Pokedex';
+import Pokemon from 'containers/Pokemon';
+import DevTools from 'containers/DevTools';
+import configureStore from 'store/configureStore';
 
 let store = configureStore();
 

--- a/src/reducers/filter.js
+++ b/src/reducers/filter.js
@@ -1,4 +1,4 @@
-import * as actionTypes from '../constants/actionTypes'
+import * as actionTypes from 'constants/actionTypes'
 import { includes } from 'lodash';
 
 export const INITIAL_STATE = {

--- a/src/reducers/pokemon.js
+++ b/src/reducers/pokemon.js
@@ -1,7 +1,7 @@
-import getPokemonId from '../helpers/get-pokemon-id';
-import getEntrypointFor from '../helpers/get-entrypoint-for';
-import * as actionTypes from '../constants/actionTypes'
-import { POKEAPI_IMAGE_URL, POKEAPI_ROOT_URL } from '../constants/services';
+import getPokemonId from 'helpers/get-pokemon-id';
+import getEntrypointFor from 'helpers/get-entrypoint-for';
+import * as actionTypes from 'constants/actionTypes'
+import { POKEAPI_IMAGE_URL, POKEAPI_ROOT_URL } from 'constants/services';
 
 export const INITIAL_STATE = {
   name: '',

--- a/src/reducers/pokemons.js
+++ b/src/reducers/pokemons.js
@@ -1,6 +1,6 @@
 import { chunk } from 'lodash';
 
-import * as actionTypes from '../constants/actionTypes';
+import * as actionTypes from 'constants/actionTypes';
 import { pokemon } from './pokemon';
 
 export const INITIAL_STATE = {

--- a/src/reducers/status.js
+++ b/src/reducers/status.js
@@ -1,5 +1,5 @@
-import { SET_STATUS } from '../constants/actionTypes';
-import { NULL_STATUS, NULL_STATUS_MESSAGE, } from '../constants/status';
+import { SET_STATUS } from 'constants/actionTypes';
+import { NULL_STATUS, NULL_STATUS_MESSAGE, } from 'constants/status';
 
 export const INITIAL_STATE = {
   status: NULL_STATUS,

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -3,8 +3,8 @@ import { reduxReactRouter } from 'redux-router';
 import { createHistory } from 'history';
 import thunk from 'redux-thunk';
 
-import rootReducer from '../reducers/rootReducer';
-import DevTools from '../containers/DevTools';
+import rootReducer from 'reducers/rootReducer';
+import DevTools from 'containers/DevTools';
 
 const createStoreWithMiddleware = compose(
   applyMiddleware(thunk),
@@ -12,7 +12,7 @@ const createStoreWithMiddleware = compose(
   reduxReactRouter({ createHistory })
 )(createStore);
 
-const root = '../reducers/rootReducer'
+const root = 'reducers/rootReducer'
 
 export default function configureStore(initialState) {
   const store = createStoreWithMiddleware(rootReducer, initialState);

--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -3,7 +3,7 @@ import { reduxReactRouter } from 'redux-router';
 import { createHistory } from 'history';
 import thunk from 'redux-thunk';
 
-import rootReducer from '../reducers/rootReducer';
+import rootReducer from 'reducers/rootReducer';
 
 const createStoreWithMiddleware = compose(
   applyMiddleware(thunk),

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -18,6 +18,13 @@ export default {
     './src/index'
   ],
 
+  resolve: {
+    modulesDirectories: [
+      'node_modules',
+      'src'
+    ]
+  },
+
   output: {
     path: path.join(__dirname, 'dist'),
     filename,


### PR DESCRIPTION
Hey!

This PR adds the [modulesDirectories](https://webpack.github.io/docs/configuration.html#resolve-modulesdirectories) property to the webpack config.

Basically it makes node to identify the configured paths as a node_module path.

Instead of doing `../../../components/title` you can simply do `components/title`, avoiding the **path hell**

This is extremely usefull when dealing with complex paths.

:)
